### PR TITLE
 Reduce thead z-index to fix issue #2

### DIFF
--- a/src/FilamentInfiniteScroll.php
+++ b/src/FilamentInfiniteScroll.php
@@ -56,7 +56,7 @@ class FilamentInfiniteScroll
                                     .fi-ta-ctn table thead {
                                         position: sticky;
                                         top: 0;
-                                        z-index: 10;
+                                        z-index: 9;
                                         background-color: white;
                                         box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
                                     }


### PR DESCRIPTION
Reducing the z-index from 10 to 9 will keep the desired position for the advanced tables plugin dropdown, while preserving table head position.

This fixes the issue #2