### PR TITLE
 Reduce thead z-index to fix issue #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to `filament-infinite-scroll` will be documented in this fil
 ## 1.0.0 - 2025-06-22
 
 - initial release
+## 1.0.2 - 2025-06-24
+-fix conflict between advanced tables plugins

--- a/src/Concerns/InteractsWithInfiniteScroll.php
+++ b/src/Concerns/InteractsWithInfiniteScroll.php
@@ -39,9 +39,4 @@ trait InteractsWithInfiniteScroll
         $this->infiniteEnded = false;
     }
 
-    public function updatedTableFilters(): void     { $this->resetInfinite(); }
-    public function updatedTableSearch(): void           { $this->resetInfinite(); }
-    public function updatedTableSortColumn(): void       { $this->resetInfinite(); }
-    public function updatedTableSortDirection(): void    { $this->resetInfinite(); }
-    public function resetTableFilters(): void            { $this->resetInfinite(); }
 }

--- a/src/FilamentInfiniteScroll.php
+++ b/src/FilamentInfiniteScroll.php
@@ -56,7 +56,7 @@ class FilamentInfiniteScroll
                                     .fi-ta-ctn table thead {
                                         position: sticky;
                                         top: 0;
-                                        z-index: 10;
+                                        z-index: 9;
                                         background-color: white;
                                         box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
                                     }

--- a/src/FilamentInfiniteScroll.php
+++ b/src/FilamentInfiniteScroll.php
@@ -30,6 +30,15 @@ class FilamentInfiniteScroll
                         $livewire->infinitePerPage = $perPage;
                     }
 
+                    if (method_exists($this, 'getLivewire')) {
+                        $livewire->listeners = array_merge($livewire->listeners ?? [], [
+                            'updatedTableFilters'        => 'resetInfinite',
+                            'updatedTableSearch'         => 'resetInfinite',
+                            'updatedTableSortColumn'     => 'resetInfinite',
+                            'updatedTableSortDirection'  => 'resetInfinite',
+                            'resetTableFilters'          => 'resetInfinite',
+                        ]);
+                    }
 
                     // Kendi div'imizi eklemek yerine, stilleri ve gözlemciyi doğrudan render ediyoruz.
                     // Bu, Filament'in kendi yapısını bozmadan çalışır.

--- a/src/FilamentInfiniteScroll.php
+++ b/src/FilamentInfiniteScroll.php
@@ -30,15 +30,16 @@ class FilamentInfiniteScroll
                         $livewire->infinitePerPage = $perPage;
                     }
 
-                    if (method_exists($this, 'getLivewire')) {
-                        $livewire->listeners = array_merge($livewire->listeners ?? [], [
-                            'updatedTableFilters'        => 'resetInfinite',
-                            'updatedTableSearch'         => 'resetInfinite',
-                            'updatedTableSortColumn'     => 'resetInfinite',
-                            'updatedTableSortDirection'  => 'resetInfinite',
-                            'resetTableFilters'          => 'resetInfinite',
+                    if (method_exists($livewire, 'mergeListeners') && method_exists($livewire, 'resetInfinite')) {
+                        $livewire->mergeListeners([
+                            'updatedTableFilters' => 'resetInfinite',
+                            'updatedTableSearch' => 'resetInfinite',
+                            'updatedTableSortColumn' => 'resetInfinite',
+                            'updatedTableSortDirection' => 'resetInfinite',
+                            'resetTableFilters' => 'resetInfinite',
                         ]);
                     }
+
 
                     // Kendi div'imizi eklemek yerine, stilleri ve gözlemciyi doğrudan render ediyoruz.
                     // Bu, Filament'in kendi yapısını bozmadan çalışır.


### PR DESCRIPTION
Reducing the z-index from 10 to 9 will keep the desired position for the advanced tables plugin dropdown, while preserving table head position.

This fixes the issue https://github.com/Fibtegis/filament-infinite-scroll/issues/2